### PR TITLE
Include additional files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
+include CHANGELOG.md
+include LICENSE
 include README.md
+include tox.ini


### PR DESCRIPTION
Including the `LICENSE` file is very important.  The other files are useful as well.